### PR TITLE
Python-3 deepcopy fix and close all files (except stdin): version 0.3.2

### DIFF
--- a/clitable.py
+++ b/clitable.py
@@ -77,6 +77,28 @@ class IndexTable(object):
     """Returns number of rows in table."""
     return self.index.size
 
+  def __copy__(self):
+    """Returns a copy of an IndexTable object."""
+    clone = IndexTable()
+    if hasattr(self, '_index_file'):
+      clone._index_file = self._index_file
+      clone._index_handle = self._index_handle
+
+    clone.index = self.index
+    clone.compiled = self.compiled
+    return clone
+
+  def __deepcopy__(self, memodict={}):
+    """Returns a deepcopy of an IndexTable object."""
+    clone = IndexTable()
+    if hasattr(self, '_index_file'):
+      clone._index_file = copy.deepcopy(self._index_file)
+      clone._index_handle = open(clone._index_file, 'r')
+
+    clone.index = copy.deepcopy(self.index)
+    clone.compiled = copy.deepcopy(self.compiled)
+    return clone
+
   def _ParseIndex(self, preread, precompile):
     """Reads index file and stores entries in TextTable.
 

--- a/clitable.py
+++ b/clitable.py
@@ -73,6 +73,11 @@ class IndexTable(object):
       self._index_handle = open(self._index_file, 'r')
       self._ParseIndex(preread, precompile)
 
+  def __del__(self):
+    """Close index handle."""
+    if hasattr(self, '_index_handle'):
+      self._index_handle.close()
+
   def __len__(self):
     """Returns number of rows in table."""
     return self.index.size
@@ -224,9 +229,14 @@ class CliTable(texttable.TextTable):
 
     template_list = template_str.split(':')
     template_files = []
-    for tmplt in template_list:
-      template_files.append(
-          open(os.path.join(self.template_dir, tmplt), 'r'))
+    try:
+      for tmplt in template_list:
+        template_files.append(
+            open(os.path.join(self.template_dir, tmplt), 'r'))
+    except:
+      for tmplt in template_files:
+        tmplt.close()
+      raise
 
     return template_files
 
@@ -257,15 +267,20 @@ class CliTable(texttable.TextTable):
                             attributes)
 
     template_files = self._TemplateNamesToFiles(templates)
-    # Re-initialise the table.
-    self.Reset()
-    self._keys = set()
-    self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])
 
-    # Add additional columns from any additional tables.
-    for tmplt in template_files[1:]:
-      self.extend(self._ParseCmdItem(self.raw, template_file=tmplt),
-                  set(self._keys))
+    try:
+      # Re-initialise the table.
+      self.Reset()
+      self._keys = set()
+      self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])
+
+      # Add additional columns from any additional tables.
+      for tmplt in template_files[1:]:
+        self.extend(self._ParseCmdItem(self.raw, template_file=tmplt),
+                    set(self._keys))
+    finally:
+      for f in template_files:
+        f.close()
 
   def _ParseCmdItem(self, cmd_input, template_file=None):
     """Creates Texttable with output of command.

--- a/terminal.py
+++ b/terminal.py
@@ -248,7 +248,8 @@ class Pager(object):
 
   The simplest usage:
 
-    s = open('file.txt').read()
+    with open('file.txt') as f:
+      s = f.read()
     Pager(s).Page()
 
   Particularly unique is the ability to sequentially feed new text into the
@@ -288,6 +289,11 @@ class Pager(object):
       self._tty = sys.stdin
     self.SetLines(None)
     self.Reset()
+
+  def __del__(self):
+    """Deconstructor, closes tty"""
+    if getattr(self, '_tty', sys.stdin) is not sys.stdin:
+        self._tty.close()
 
   def Reset(self):
     """Reset the pager to the top of the text."""
@@ -465,8 +471,10 @@ def main(argv=None):
       raise Usage('Invalid arguments.')
 
   # Page text supplied in either specified file or stdin.
+
   if len(args) == 1:
-    fd = open(args[0]).read()
+    with open(args[0]) as f:
+      fd = f.read()
   else:
     fd = sys.stdin.read()
   Pager(fd, delay=isdelay).Page()

--- a/textfsm.py
+++ b/textfsm.py
@@ -26,7 +26,7 @@ for each input entity.
 """
 from __future__ import print_function
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 import getopt
 import inspect

--- a/textfsm.py
+++ b/textfsm.py
@@ -1007,25 +1007,29 @@ def main(argv=None):
 
   # If we have an argument, parse content of file and display as a template.
   # Template displayed will match input template, minus any comment lines.
-  template = open(args[0], 'r')
-  fsm = TextFSM(template)
-  print('FSM Template:\n%s\n' % fsm)
+  with open(args[0], 'r') as template:
+    fsm = TextFSM(template)
+    print('FSM Template:\n%s\n' % fsm)
 
-  if len(args) > 1:
-    # Second argument is file with example cli input.
-    # Prints parsed tabular result.
-    cli_input = open(args[1], 'r').read()
-    table = fsm.ParseText(cli_input)
-    print('FSM Table:')
-    result = str(fsm.header) + '\n'
-    for line in table:
-      result += str(line) + '\n'
-    print(result, end='')
+    if len(args) > 1:
+      # Second argument is file with example cli input.
+      # Prints parsed tabular result.
+      with open(args[1], 'r') as f:
+        cli_input = f.read()
+
+      table = fsm.ParseText(cli_input)
+      print('FSM Table:')
+      result = str(fsm.header) + '\n'
+      for line in table:
+        result += str(line) + '\n'
+      print(result, end='')
 
   if len(args) > 2:
     # Compare tabular result with data in third file argument.
     # Exit value indicates if processed data matched expected result.
-    ref_table = open(args[2], 'r').read()
+    with open(args[2], 'r') as f:
+      ref_table = f.read()
+
     if ref_table != result:
       print('Data mis-match!')
       return 1


### PR DESCRIPTION
This pull request fixes the tests for Python 3. The file handler in the IndexTable object is not serializable in Python 3, so `__copy__` and `__deepcopy__` must be overriden to be able to copy them.

This also fixes dangling file descriptors, any opened file must be closed. `stdin` is kept opened so that it can be reused later on. Python 3 issues a warning when such a thing happen, Python 2 does not.