### PR TITLE
Nested list matching

### DIFF
--- a/textfsm.py
+++ b/textfsm.py
@@ -178,7 +178,9 @@ class TextFSMOptions(object):
 
     def OnAssignVar(self):
       match = re.match(self.value.regex, self.value.value)
-      if match:
+      # If the List-value regex has match-groups defined, add the grouped results to the list
+      # Otherwise, add the string that was matched
+      if match and match.groupdict():
           self._value.append(match.groupdict())
       else:
           self._value.append(self.value.value)

--- a/textfsm.py
+++ b/textfsm.py
@@ -177,7 +177,6 @@ class TextFSMOptions(object):
       self.OnClearAllVar()
 
     def OnAssignVar(self):
-      self._value.append(self.value.value)
       match = re.match(self.value.regex, self.value.value)
       if match:
           self._value.append(match.groupdict())

--- a/textfsm.py
+++ b/textfsm.py
@@ -178,6 +178,11 @@ class TextFSMOptions(object):
 
     def OnAssignVar(self):
       self._value.append(self.value.value)
+      match = re.match(self.value.regex, self.value.value)
+      if match:
+          self._value.append(match.groupdict())
+      else:
+          self._value.append(self.value.value)
 
     def OnClearVar(self):
       if 'Filldown' not in self.value.OptionNames():
@@ -910,7 +915,9 @@ class TextFSM(object):
       matched: (regexp.match) Named group for each matched value.
       value: (str) The matched value.
     """
-    self._GetValue(value).AssignVar(matched.group(value))
+    _value = self._GetValue(value)
+    if _value is not None:
+        _value.AssignVar(matched.group(value))
 
   def _Operations(self, rule):
     """Operators on the data record.

--- a/textfsm.py
+++ b/textfsm.py
@@ -315,7 +315,10 @@ class TextFSMValue(object):
 
     # Compile and store the regex object only on List-type values for use in nested matching
     if any(map(lambda x: isinstance(x, TextFSMOptions.List), self.options)):
-        self.compiled_regex = re.compile(self.regex)
+        try:
+            self.compiled_regex = re.compile(self.regex)
+        except re.error as e:
+            raise TextFSMTemplateError(str(e))
 
   def _AddOption(self, name):
     """Add an option to this Value.

--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -610,6 +610,26 @@ State1
     result = t.ParseText(data)
     self.assertEqual(str(result), ("[[['one'], 'two']]"))
 
+
+  def testNestedMatching(self):
+      """
+      Ensures that List-type values with nested regex capture groups are parsed correctly
+      as a list of dictionaries.
+      """
+      tplt = (
+          "Value List foo ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)\n\n"
+          "Start\n  ^\s*${foo}\n  ^\s*$$ -> Record"
+      )
+      t = textfsm.TextFSM(StringIO(tplt))
+      data = " Bob: 32 NC\n Alice: 27 NY\n Jeff: 45 CA\n\n"
+      result = t.ParseText(data)
+      self.assertEqual(
+          str(result), (
+              "[[[{'name': 'Bob', 'age': '32', 'state': 'NC'}, "
+              "{'name': 'Alice', 'age': '27', 'state': 'NY'}, "
+              "{'name': 'Jeff', 'age': '45', 'state': 'CA'}]]]"
+      ))
+
   def testGetValuesByAttrib(self):
 
     tplt = ('Value Required boo (on.)\n'

--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -615,19 +615,23 @@ State1
       """
       Ensures that List-type values with nested regex capture groups are parsed correctly
       as a list of dictionaries.
+
+      Additionaly, another value is used with the same group-name as one of the nested groups to ensure that
+      there are no conflicts when the same name is used.
       """
       tplt = (
-          "Value List foo ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)\n\n"
-          "Start\n  ^\s*${foo}\n  ^\s*$$ -> Record"
+          "Value List foo ((?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)\n"  # A nested group is called "name"
+          "Value name (\w+)\n\n"  # A regular value is called "name"
+          "Start\n  ^\s*${foo}\n  ^\s*${name}\n  ^\s*$$ -> Record"  # "${name}" here refers to the Value called "name"
       )
       t = textfsm.TextFSM(StringIO(tplt))
-      data = " Bob: 32 NC\n Alice: 27 NY\n Jeff: 45 CA\n\n"
+      data = " Bob: 32 NC\n Alice: 27 NY\n Jeff: 45 CA\nJulia\n\n"  # Julia should be parsed as "name" separately
       result = t.ParseText(data)
       self.assertEqual(
           str(result), (
               "[[[{'name': 'Bob', 'age': '32', 'state': 'NC'}, "
               "{'name': 'Alice', 'age': '27', 'state': 'NY'}, "
-              "{'name': 'Jeff', 'age': '45', 'state': 'CA'}]]]"
+              "{'name': 'Jeff', 'age': '45', 'state': 'CA'}], 'Julia']]"
       ))
 
   def testGetValuesByAttrib(self):

--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -634,6 +634,15 @@ State1
               "{'name': 'Jeff', 'age': '45', 'state': 'CA'}], 'Julia']]"
       ))
 
+  def testNestedNameConflict(self):
+      tplt = (
+          # Two nested groups are called "name"
+          "Value List foo ((?P<name>\w+)\s+(?P<name>\w+):\s+(?P<age>\d+)\s+(?P<state>\w{2})\s*)\n"
+          "Start\n  ^\s*${foo}\n  ^\s*$$ -> Record"
+      )
+      self.assertRaises(textfsm.TextFSMTemplateError, textfsm.TextFSM, StringIO(tplt))
+
+
   def testGetValuesByAttrib(self):
 
     tplt = ('Value Required boo (on.)\n'


### PR DESCRIPTION
\# Ignore the 'Repeat' keyword from this template. 
\# That is from another pull request, and the features are separate. 



Using a template like the one below, it is now possible to parse lines, to be inserted into a List-type value, into dictionaries as opposed to strings. The key line of interest here is where the "Prefixes" list is defined.
```
Value lspid (\S+)
Value lsp_seq_num (\S+)
Value lsp_checksum (\S+)
Value lsp_holdtime (\d+|\d+\s+\(\d+\))
Value att (\d+)
Value p (\d+)
Value ol (\d+)
Value hostname (\S+)
Value ipv4_address (\S+)
Value ipv6_address (\S+)
Value router_id (\S+)
Value router_cap (\S+)
Value List prefixes (Metric:\s+(?P<metric>\d+)\s+(?P<prefix_type>.+)\s+(?P<prefix>\S+$))

Start
  ^${lspid}[*\s]+${lsp_seq_num}\s+${lsp_checksum}\s+${lsp_holdtime}\s+${att}/${p}/${ol}
  ^\s+Hostname:\s+${hostname}
  ^\s+IP Address:\s+${ipv4_address}
  ^\s+IPv6 Address:\s+${ipv6_address}
  ^\s+Router ID:\s+${router_id} -> Prefixes

Prefixes
  ^\s+${prefixes} 
  ^\S -> Repeat.Record Start
```

Some sample input:
```
foobar.00-00      * 0x000022a3   0x9417        1215            0/0/0
  Area Address:   00.000f.0011.0000.0000.0001.0000
  NLPID:          0xcc
  NLPID:          0x8e
  MT:             Standard (IPv4 Unicast)
  MT:             IPv6 Unicast                                 0/0/0
  Hostname:       foobar
  IP Address:     10.0.0.1
  IPv6 Address:   0000:00:255:255::1
  Router ID:      255.255.255.255
  Metric: 10         IS-Extended apple.00
  Metric: 10         IS-Extended apple-31.00
  Metric: 1000       IS-Extended quinoa.00
  Metric: 10         IP-Extended 11.11.11.0/30
  Metric: 10         IP-Extended 11.11.11.2/31
  Metric: 10         IP-Extended 11.11.111.0/30
  Metric: 10         IP-Extended 11.11.111.0/30
  Metric: 1000       IP-Extended 11.11.11.11/24
```

And the output:
```
[{'att': '0',
  'hostname': 'foobar',
  'ipv4_address': '10.0.0.1',
  'ipv6_address': '0000:00:255:255::1',
  'lsp_checksum': '0x9417',
  'lsp_holdtime': '1215',
  'lsp_seq_num': '0x000022a3',
  'lspid': 'foobar.00-00',
  'ol': '0',
  'p': '0',
  'prefixes': [{'metric': '10',
                'prefix': 'apple.00',
                'prefix_type': 'IS-Extended'},
               {'metric': '10',
                'prefix': 'apple-31.00',
                'prefix_type': 'IS-Extended'},
               {'metric': '1000',
                'prefix': 'quinoa.00',
                'prefix_type': 'IS-Extended'},
               {'metric': '10',
                'prefix': '11.11.11.0/30',
                'prefix_type': 'IP-Extended'},
               {'metric': '10',
                'prefix': '11.11.11.2/31',
                'prefix_type': 'IP-Extended'},
               {'metric': '10',
                'prefix': '11.11.111.0/30',
                'prefix_type': 'IP-Extended'},
               {'metric': '10',
                'prefix': '11.11.111.0/30',
                'prefix_type': 'IP-Extended'},
               {'metric': '1000',
                'prefix': '11.11.11.11/24',
                'prefix_type': 'IP-Extended'}],
  'router_cap': '',
  'router_id': '255.255.255.255'}]
```