### PR TITLE
textfsm_test: do not relay on dic order

### DIFF
--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -628,10 +628,12 @@ State1
       data = " Bob: 32 NC\n Alice: 27 NY\n Jeff: 45 CA\nJulia\n\n"  # Julia should be parsed as "name" separately
       result = t.ParseText(data)
       self.assertEqual(
-          str(result), (
-              "[[[{'name': 'Bob', 'age': '32', 'state': 'NC'}, "
-              "{'name': 'Alice', 'age': '27', 'state': 'NY'}, "
-              "{'name': 'Jeff', 'age': '45', 'state': 'CA'}], 'Julia']]"
+          result, (
+              [[[
+                {'name': 'Bob', 'age': '32', 'state': 'NC'},
+                {'name': 'Alice', 'age': '27', 'state': 'NY'},
+                {'name': 'Jeff', 'age': '45', 'state': 'CA'}
+              ], 'Julia']]
       ))
 
   def testNestedNameConflict(self):


### PR DESCRIPTION
The test `testNestedMatching` compares a list of dictionaries with
a string.  In Python 2 (and some versions of Python 3) the order
of a dictionary is not guaranteed, and this makes the test to fail.

This patch compares the raw result with the raw list, and assetEqual
takes care of the ordering.