### PR TITLE
Fix encoding issues when installing the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md')) as f:
+with open(path.join(here, 'README.md'), encoding="utf8") as f:
     long_description = f.read()
 
 setup(name='textfsm',


### PR DESCRIPTION
This should fix #34.
https://docs.python.org/3.4/library/codecs.html#codecs.open
https://stackoverflow.com/questions/28431269/typeerror-type-str-doesnt-support-the-buffer-api-when-splitting-string