### PR TITLE
Add Repeated option and port re to regex module.

### DIFF
--- a/clitable.py
+++ b/clitable.py
@@ -27,7 +27,7 @@ the TextFSM output parser.
 
 import copy
 import os
-import re
+import regex
 import threading
 import copyable_regex_object
 import textfsm
@@ -314,7 +314,7 @@ class CliTable(texttable.TextTable):
   def _PreParse(self, key, value):
     """Executed against each field of each row read from index table."""
     if key == 'Command':
-      return re.sub(r'(\[\[.+?\]\])', self._Completion, value)
+      return regex.sub(r'(\[\[.+?\]\])', self._Completion, value)
     else:
       return value
 

--- a/clitable_test.py
+++ b/clitable_test.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 
 import copy
 import os
-import re
+import regex
 import unittest
 
 import clitable
@@ -104,11 +104,11 @@ class UnitTestCliTable(unittest.TestCase):
   def testCompletion(self):
     """Tests '[[]]' syntax replacement."""
     indx = clitable.CliTable()
-    self.assertEqual('abc', re.sub(r'(\[\[.+?\]\])', indx._Completion, 'abc'))
+    self.assertEqual('abc', regex.sub(r'(\[\[.+?\]\])', indx._Completion, 'abc'))
     self.assertEqual('a(b(c)?)?',
-                     re.sub(r'(\[\[.+?\]\])', indx._Completion, 'a[[bc]]'))
+                     regex.sub(r'(\[\[.+?\]\])', indx._Completion, 'a[[bc]]'))
     self.assertEqual('a(b(c)?)? de(f)?',
-                     re.sub(r'(\[\[.+?\]\])', indx._Completion,
+                     regex.sub(r'(\[\[.+?\]\])', indx._Completion,
                             'a[[bc]] de[[f]]'))
 
   def testRepeatRead(self):

--- a/copyable_regex_object.py
+++ b/copyable_regex_object.py
@@ -16,16 +16,16 @@
 
 """Work around a regression in Python 2.6 that makes RegexObjects uncopyable."""
 
-import re
+import regex
 
 
 class CopyableRegexObject(object):
-  """Like a re.RegexObject, but can be copied."""
+  """Like a regex.RegexObject, but can be copied."""
   # pylint: disable=C6409
 
   def __init__(self, pattern):
     self.pattern = pattern
-    self.regex = re.compile(pattern)
+    self.regex = regex.compile(pattern)
 
   def match(self, *args, **kwargs):
     return self.regex.match(*args, **kwargs)

--- a/examples/repeated_basic_example
+++ b/examples/repeated_basic_example
@@ -1,0 +1,7 @@
+This is an example to demonstrate the usage of the 'repeated' keyword, which enables one variable to have multiple captures on one line.
+
+
+normaldata1.1 normaldata1.2 key1.1:data1.1, key1.2:data1.2, key1.3:data1.3, normaldata1.3 normaldata1.3
+normaldata2.1 normaldata2.2 key2.1:data2.1, key2.2:data2.2, normaldata2.3 normaldata2.4
+normaldata3.1 normaldata3.2 normaldata3.3 normaldata3.4
+normaldata4.1 normaldata4.2 key4.1:data4.1, key4.2:data4.2, key4.3:data4.3, normaldata4.3 normaldata4.3

--- a/examples/repeated_basic_template
+++ b/examples/repeated_basic_template
@@ -1,0 +1,12 @@
+Value normaldata1 (\S+)
+Value normaldata2 (\S+)
+Value normaldata3 (\S+)
+Value normaldata4 (\S+)
+Value Repeated keything (\S+)
+Value Repeated valuedata (\S+)
+Value Repeated unusedRepeated (\S+)
+Value List unused (\S+)
+
+
+Start
+  ^${normaldata1}\s+${normaldata2} (${keything}:${valuedata},? )*${normaldata3}\s+${normaldata4} -> Record

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(name='textfsm',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
           'Topic :: Software Development :: Libraries'],
-      requires=['six'],
+      requires=['six', 'regex'],
       py_modules=['clitable', 'textfsm', 'copyable_regex_object',
                   'texttable', 'terminal'])

--- a/terminal.py
+++ b/terminal.py
@@ -28,7 +28,7 @@ __version__ = '0.1.1'
 import fcntl
 import getopt
 import os
-import re
+import regex
 import struct
 import sys
 import termios
@@ -100,7 +100,7 @@ ANSI_START = '\001'
 ANSI_END = '\002'
 
 
-sgr_re = re.compile(r'(%s?\033\[\d+(?:;\d+)*m%s?)' % (
+sgr_re = regex.compile(r'(%s?\033\[\d+(?:;\d+)*m%s?)' % (
     ANSI_START, ANSI_END))
 
 
@@ -159,12 +159,12 @@ def AnsiText(text, command_list=None, reset=True):
 
 def StripAnsiText(text):
   """Strip ANSI/SGR escape sequences from text."""
-  return sgr_re.sub('', text)
+  return sgr_regex.sub('', text)
 
 
 def EncloseAnsiText(text):
   """Enclose ANSI/SGR escape sequences with ANSI_START and ANSI_END."""
-  return sgr_re.sub(lambda x: ANSI_START + x.group(1) + ANSI_END, text)
+  return sgr_regex.sub(lambda x: ANSI_START + x.group(1) + ANSI_END, text)
 
 
 def TerminalSize():
@@ -195,7 +195,7 @@ def LineWrap(text, omit_sgr=False):
 
   def _SplitWithSgr(text_line):
     """Tokenise the line so that the sgr sequences can be omitted."""
-    token_list = sgr_re.split(text_line)
+    token_list = sgr_regex.split(text_line)
     text_line_list = []
     line_length = 0
     for (index, token) in enumerate(token_list):
@@ -203,7 +203,7 @@ def LineWrap(text, omit_sgr=False):
       if token is '':
         continue
 
-      if sgr_re.match(token):
+      if sgr_regex.match(token):
         # Add sgr escape sequences without splitting or counting length.
         text_line_list.append(token)
         text_line = ''.join(token_list[index +1:])

--- a/textfsm.py
+++ b/textfsm.py
@@ -135,6 +135,15 @@ class TextFSMOptions(object):
     def OnAssignVar(self):
       self.value.value = self.value.values_list
 
+    def OnCreateOptions(self):
+      self.value.value = []
+
+    def OnClearVar(self):
+      self.value.value = []
+
+    def OnClearAllVar(self):
+      self.value.value = []
+
   class Required(OptionBase):
     """The Value must be non-empty for the row to be recorded."""
 
@@ -203,7 +212,7 @@ class TextFSMOptions(object):
       # If the List-value regex has match-groups defined, add the resulting dict to the list
       # Otherwise, add the string that was matched
       if match and match.capturesdict():
-          self._value.append(match.capturesdict())
+          self._value.append({x: match.capturesdict()[x][-1] for x in match.capturesdict()})
       else:
           self._value.append(self.value.value)
 
@@ -254,7 +263,10 @@ class TextFSMValue(object):
 
   def AssignVar(self, value):
     """Assign a value to this Value."""
-    self.value = value[-1]
+    try:
+      self.value = value[-1]
+    except IndexError:
+      self.value = ''
     self.values_list = value
     # Call OnAssignVar on options.
     _ = [option.OnAssignVar() for option in self.options]

--- a/textfsm.py
+++ b/textfsm.py
@@ -478,29 +478,29 @@ class TextFSMRule(object):
       return
 
     # Attempt to match line.record operation.
-    action_re = self.ACTION_regex.match(match_action.group('action'))
+    action_re = self.ACTION_RE.match(match_action.group('action'))
     if not action_re:
       # Attempt to match record operation.
-      action_re = self.ACTION2_regex.match(match_action.group('action'))
+      action_re = self.ACTION2_RE.match(match_action.group('action'))
       if not action_re:
         # Math implicit defaults with an optional new state.
-        action_re = self.ACTION3_regex.match(match_action.group('action'))
+        action_re = self.ACTION3_RE.match(match_action.group('action'))
         if not action_re:
           # Last attempt, match an optional new state only.
           raise TextFSMTemplateError("Badly formatted rule '%s'. Line: %s." %
                                      (line, self.line_num))
 
     # We have an Line operator.
-    if 'ln_op' in action_regex.groupdict() and action_regex.group('ln_op'):
-      self.line_op = action_regex.group('ln_op')
+    if 'ln_op' in action_re.groupdict() and action_re.group('ln_op'):
+      self.line_op = action_re.group('ln_op')
 
     # We have a record operator.
-    if 'rec_op' in action_regex.groupdict() and action_regex.group('rec_op'):
-      self.record_op = action_regex.group('rec_op')
+    if 'rec_op' in action_re.groupdict() and action_re.group('rec_op'):
+      self.record_op = action_re.group('rec_op')
 
     # A new state was specified.
-    if 'new_state' in action_regex.groupdict() and action_regex.group('new_state'):
-      self.new_state = action_regex.group('new_state')
+    if 'new_state' in action_re.groupdict() and action_re.group('new_state'):
+      self.new_state = action_re.group('new_state')
 
     # Only 'Next' (or implicit 'Next') line operator can have a new_state.
     # But we allow error to have one as a warning message so we are left

--- a/textfsm.py
+++ b/textfsm.py
@@ -106,7 +106,6 @@ class TextFSMOptions(object):
     def OnAssignVar(self):
       """Called when a matched value is being assigned."""
 
-
     def OnGetValue(self):
       """Called when the value name is being requested."""
 

--- a/textfsm.py
+++ b/textfsm.py
@@ -775,7 +775,7 @@ class TextFSM(object):
       # First line is state definition
       if line and not self.comment_regex.match(line):
          # Ensure statename has valid syntax and is not a reserved word.
-        if (not self.state_name_regex.match(line) or
+        if (not self.state_name_re.match(line) or
             len(line) > self.MAX_NAME_LEN or
             line in TextFSMRule.LINE_OP or
             line in TextFSMRule.RECORD_OP):

--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -513,15 +513,22 @@ State1
     # Tests 'Filldown' and 'Required' options.
     data = 'two\none'
     result = t.ParseTextToDicts(data)
-    self.assertEqual(str(result), "[{'hoo': 'two', 'boo': 'one'}]")
+    try:
+      self.assertEqual(str(result), "[{'hoo': 'two', 'boo': 'one'}]")
+    except AssertionError:
+      self.assertEqual(str(result), "[{'boo': 'one', 'hoo': 'two'}]")
 
     t = textfsm.TextFSM(StringIO(tplt))
     # Matching two lines. Two records returned due to 'Filldown' flag.
     data = 'two\none\none'
     t.Reset()
     result = t.ParseTextToDicts(data)
-    self.assertEqual(
-        str(result), "[{'hoo': 'two', 'boo': 'one'}, {'hoo': 'two', 'boo': 'one'}]")
+    try:
+      self.assertEqual(
+          str(result), "[{'hoo': 'two', 'boo': 'one'}, {'hoo': 'two', 'boo': 'one'}]")
+    except AssertionError:
+      self.assertEqual(
+        str(result), "[{'boo': 'one', 'hoo': 'two'}, {'boo': 'one', 'hoo': 'two'}]")
 
     # Multiple Variables and options.
     tplt = ('Value Required,Filldown boo (one)\n'
@@ -531,8 +538,12 @@ State1
     t = textfsm.TextFSM(StringIO(tplt))
     data = 'two\none\none'
     result = t.ParseTextToDicts(data)
-    self.assertEqual(
-        str(result), "[{'hoo': 'two', 'boo': 'one'}, {'hoo': 'two', 'boo': 'one'}]")
+    try:
+      self.assertEqual(
+          str(result), "[{'hoo': 'two', 'boo': 'one'}, {'hoo': 'two', 'boo': 'one'}]")
+    except AssertionError:
+      self.assertEqual(
+        str(result), "[{'boo': 'one', 'hoo': 'two'}, {'boo': 'one', 'hoo': 'two'}]")
 
   def testParseNullText(self):
 

--- a/textfsm_test.py
+++ b/textfsm_test.py
@@ -808,7 +808,7 @@ State1
 
   def testInvalidRegexp(self):
 
-    tplt = 'Value boo (.$*)\n\nStart\n  ^$boo -> Next\n'
+    tplt = 'Value boo ([(\S+]))\n\nStart\n  ^$boo -> Next\n'
     self.assertRaises(textfsm.TextFSMTemplateError,
                       textfsm.TextFSM, StringIO(tplt))
 
@@ -856,6 +856,28 @@ Start
         "[['1', 'A2', 'B1'], ['2', 'A2', 'B3'], ['3', '', 'B3']]",
         str(result))
 
+
+  def testRepeated(self):
+    """Repeated option should work ok."""
+    tplt = """Value Repeated repeatedKey (\S+)
+Value Repeated repeatedValue (\S+)
+Value normalData (\S+)
+Value normalData2 (\S+)
+Value Repeated repeatedUnused (\S+)
+
+Start
+  ^${normalData} (${repeatedKey}:${repeatedValue} )*${normalData2} -> Record"""
+
+    data = """
+normal1 key1:value1 key2:value2 key3:value3 normal2 \n
+normal1 normal2 """
+
+    t = textfsm.TextFSM(StringIO(tplt))
+    result = t.ParseText(data)
+    self.assertEqual(
+      "[[['key1', 'key2', 'key3'], ['value1', 'value2', 'value3'], 'normal1', 'normal2', []],"
+      + " [[], [], 'normal1', 'normal2', []]]",
+      str(result))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fixes #18 

Instances or re were changed to [regex](https://pypi.org/project/regex/). This allows for increased matching power. 
Repeated as asked for in issue #18 was added using the new regex module functionality. Test cases were updated to reflect the increased functionality and new option.