### PR TITLE
to take environ python path

### DIFF
--- a/textfsm/parser.py
+++ b/textfsm/parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2010 Google Inc. All Rights Reserved.
 #


### PR DESCRIPTION
Even when we try to run textfsm in vritualenv, it was picking base python.

In case base python if its 2.x, it will even throw error

```
(textfsm) (base) nitinkr-mbp:textfsm nitinkr$ .parser.py
Traceback (most recent call last):
  File "./textfsm/textfsm/parser.py", line 38, in <module>
    from builtins import object   # pylint: disable=redefined-builtin
ImportError: No module named builtins
```