### PR TITLE
Fix deprecation warning regarding invalid escape sequences and comparison of literals.

### DIFF
--- a/tests/textfsm_test.py
+++ b/tests/textfsm_test.py
@@ -79,7 +79,7 @@ class UnitTestFSM(unittest.TestCase):
     # Escaped braces don't count.
     self.assertRaises(textfsm.TextFSMTemplateError,
                       v.Parse,
-                      'Value beer (boo\[)\]hoo)')
+                      r'Value beer (boo\[)\]hoo)')
 
     # String function.
     v = textfsm.TextFSMValue(options_class=textfsm.TextFSMOptions)

--- a/textfsm/terminal.py
+++ b/textfsm/terminal.py
@@ -204,7 +204,7 @@ def LineWrap(text, omit_sgr=False):
     line_length = 0
     for (index, token) in enumerate(token_list):
       # Skip null tokens.
-      if token is '':
+      if token == '':
         continue
 
       if sgr_re.match(token):


### PR DESCRIPTION
Fixes #79 