### PR TITLE
Fix regex parsing for parentheses

### DIFF
--- a/tests/textfsm_test.py
+++ b/tests/textfsm_test.py
@@ -70,6 +70,18 @@ class UnitTestFSM(unittest.TestCase):
                       v.Parse,
                       'Value beer (boo)hoo)')
 
+    # Escaped parentheses don't count.
+    v = textfsm.TextFSMValue(options_class=textfsm.TextFSMOptions)
+    v.Parse(r'Value beer (boo\)hoo)')
+    self.assertEqual(v.name, 'beer')
+    self.assertEqual(v.regex, r'(boo\)hoo)')
+    self.assertRaises(textfsm.TextFSMTemplateError,
+                      v.Parse,
+                      r'Value beer (boohoo\)')
+    self.assertRaises(textfsm.TextFSMTemplateError,
+                      v.Parse,
+                      r'Value beer (boo)hoo\)')
+
     # Unbalanced parenthesis can exist if within square "[]" braces.
     v = textfsm.TextFSMValue(options_class=textfsm.TextFSMOptions)
     v.Parse('Value beer (boo[(]hoo)')

--- a/textfsm/parser.py
+++ b/textfsm/parser.py
@@ -313,22 +313,20 @@ class TextFSMValue(object):
       raise TextFSMTemplateError(
           "Invalid Value name '%s' or name too long." % self.name)
 
-    square_brackets = r'[^\]?\[[^]]*\]'
-    regex_without_brackets = re.sub(square_brackets, '', self.regex)
-    if (not re.match(r'^\(.*\)$', self.regex) or
-        regex_without_brackets.count('(') != regex_without_brackets.count(')')):
+    if self.regex[0]!='(' or self.regex[-1]!=')' or self.regex[-2]=='\\':
       raise TextFSMTemplateError(
           "Value '%s' must be contained within a '()' pair." % self.regex)
+    try:
+      compiled_regex = re.compile(self.regex)
+    except re.error as e:
+      raise TextFSMTemplateError(str(e))
 
     self.template = re.sub(r'^\(', '(?P<%s>' % self.name, self.regex)
 
     # Compile and store the regex object only on List-type values for use in
     # nested matching
     if any([isinstance(x, TextFSMOptions.List) for x in self.options]):
-      try:
-        self.compiled_regex = re.compile(self.regex)
-      except re.error as e:
-        raise TextFSMTemplateError(str(e))
+      self.compiled_regex = compiled_regex
 
   def _AddOption(self, name):
     """Add an option to this Value.


### PR DESCRIPTION
This fixes the check for values' regexes to be enclosed within parentheses

(I am contributing this patch as an employee of Optiver, ready to sign a CLA)

## Issue
- Define a value with the regex `(boo\)hoo)`
- Both `(boo\)hoo)` and `boo\)hoo` are valid regexes, so this should work
- However, this raises a `TextFSMTemplateError` instead

## Background
Each value definition requires a valid regex which, as mentioned in the [wiki](https://github.com/google/textfsm/wiki/TextFSM#value-definitions), must be enclosed within parentheses. It is easy to check whether the regex starts with `(` and ends with a non-escaped `)` but the hard part is making sure that the ending `)` matches the starting `(`.

This used to be enforced by:
- Making sure the regex starts with `(` and ends with `)`
- Making sure the regex contains as many `(` as `)`

This was not a correct check, so google#68 changed it to:
- Making sure the regex starts with `(` and ends with `)`
- Making sure the regex contains as many `(` as `)` while [ignoring any portion of the regex enclosed within non-escaped brackets](https://github.com/google/textfsm/blob/8d5aaad7018422f95e38b66f8e23711af9a989a8/textfsm/parser.py#L316-L321)

This is still not a correct check:
- It still fails on `(boo\)hoo)`
- It is implemented incorrectly, so it also fails on `([boo(hoo)])`

## Proposed fix
- The problem of enforcing that the regex starts with a `(` and ends with a matching, non-escaped `)` is non-trivial
- This can easily be offloaded to the `re` library by compiling the regex
