### PR TITLE
Refactor pager class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 
 /dist/
+/build/
 
 /*.egg-info

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -117,10 +117,10 @@ class FakeTerminal(object):
   # pylint: disable=C6409
   def CountLines(self):
     return len(self.output.splitlines())
-  
+
   def Show(self):
     return self.output
-  
+
   def Clear(self):
     self.output = ''
 
@@ -134,7 +134,7 @@ class PagerTest(unittest.TestCase):
     super(PagerTest, self).setUp()
     self._output = FakeTerminal()
     sys.stdout = self._output
-    self._GetChar_orig = terminal._GetChar
+    self._getchar_orig = terminal._GetChar
     # Quit the pager immediately after the first page.
     terminal._GetChar = lambda: 'q'
 
@@ -148,7 +148,7 @@ class PagerTest(unittest.TestCase):
 
   def tearDown(self):
     super(PagerTest, self).tearDown()
-    terminal._GetChar = self._GetChar_orig
+    terminal._GetChar = self._getchar_orig
     sys.stdout = sys.__stdout__
 
   def testDisplay(self):
@@ -172,29 +172,29 @@ class PagerTest(unittest.TestCase):
     self.assertEqual(self._output.Show(), '7\n8\n9\n')
 
   def testPageAddsText(self):
-    _extra_text = '10\n11\n'
-    self.p.Page(_extra_text)
-    self.assertEqual(self.p._text, self._sample_text + _extra_text)
+    extra_text = '10\n11\n'
+    self.p.Page(extra_text)
+    self.assertEqual(self.p._text, self._sample_text + extra_text)
 
   def testPage(self):
     self.p.SetLines(3)
     self.p.Page()
     self.assertEqual(
-      self._output.Show().splitlines()[:-self._prompt_lines], ['0', '1', '2'])
-  
+        self._output.Show().splitlines()[:-self._prompt_lines], ['0', '1', '2'])
+
   def testPrompt(self):
     self.p.SetLines(2)
     # After paging once the progress will be 20%.
     self.p.Page()
     self._output.Clear()
     self.assertEqual(self.p._Prompt(), terminal.AnsiText(
-      'n: next line, Space: next page, b: prev page, q: quit.',
-      ['green']))
+        'n: next line, Space: next page, b: prev page, q: quit.',
+        ['green']))
     # truncate width to 10 cols, prompt should be likewise truncated.
     self.p._cols = 10
     self.assertEqual(self.p._Prompt(),
                      terminal.AnsiText('n: next li', ['green']))
-    
+
   def testPagerClear(self):
     self.p.SetLines(2)
     self.p.Page()
@@ -210,34 +210,34 @@ class PagerTest(unittest.TestCase):
     self.p.SetLines(2)
     self.p.Page()
     self.assertEqual(terminal.StripAnsiText(
-      self._output.Show().splitlines()[-self._prompt_lines]),
-      terminal.PROMPT_QUESTION + ' (20%)')
+        self._output.Show().splitlines()[-self._prompt_lines]),
+                     terminal.PROMPT_QUESTION + ' (20%)')
     self.p.Page()
     self.assertEqual(terminal.StripAnsiText(
-      self._output.Show().splitlines()[-self._prompt_lines]),
-      terminal.PROMPT_QUESTION + ' (40%)')
+        self._output.Show().splitlines()[-self._prompt_lines]),
+                     terminal.PROMPT_QUESTION + ' (40%)')
     self.p.Page('10\n11\n')
     # 50%, rather than 60%, as the total size increased from 10 to 12.
     # But we don't show percent, as the source is streamed.
     self.assertEqual(terminal.StripAnsiText(
-      self._output.Show().splitlines()[-self._prompt_lines]),
-      terminal.PROMPT_QUESTION)
+        self._output.Show().splitlines()[-self._prompt_lines]),
+                     terminal.PROMPT_QUESTION)
     self.p.Page('12\n13\n14\n15')
     self.assertEqual(terminal.StripAnsiText(
-      self._output.Show().splitlines()[-self._prompt_lines]),
-      terminal.PROMPT_QUESTION)
+        self._output.Show().splitlines()[-self._prompt_lines]),
+                     terminal.PROMPT_QUESTION)
     self.p.Page()
     self.assertEqual(terminal.StripAnsiText(
-      self._output.Show().splitlines()[-self._prompt_lines]),
-      terminal.PROMPT_QUESTION + ' (%d%%)' % (10 / 16 * 100))
+        self._output.Show().splitlines()[-self._prompt_lines]),
+                     terminal.PROMPT_QUESTION + ' (%d%%)' % (10 / 16 * 100))
 
   def testBlankLines(self):
-    _buffer = 'First line.\n\nThird line.\n'
-    self.p = terminal.Pager(_buffer)
+    buffer = 'First line.\n\nThird line.\n'
+    self.p = terminal.Pager(buffer)
     self.p.SetLines(4)
     self.p.Page()
     self.assertEqual(self._output.Show().splitlines()[:-self._prompt_lines],
-      _buffer.splitlines())
+                     buffer.splitlines())
 
 
 if __name__ == '__main__':

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -151,22 +151,22 @@ class PagerTest(unittest.TestCase):
 
   def testDisplay(self):
     # Display a couple of rows (20%).
-    self.assertEqual(self.p._Display(0, 2), (2, 20.0))
+    self.assertEqual(self.p._Display(0, 2), (2, 20.0, 10))
     self.assertEqual(self._output.Show(), '0\n1\n')
     self._output.Clear()
-    self.assertEqual(self.p._Display(3, 2), (5, 50.0))
+    self.assertEqual(self.p._Display(3, 2), (5, 50.0, 10))
     self.assertEqual(self._output.Show(), '3\n4\n')
     self._output.Clear()
     # Display past the end of the text.
-    self.assertEqual(self.p._Display(8, 3), (10, 100.0))
+    self.assertEqual(self.p._Display(8, 3), (10, 100.0, 10))
     self.assertEqual(self._output.Show(), '8\n9\n')
     self._output.Clear()
     # Display before the start. Displays form the start.
-    self.assertEqual(self.p._Display(-1, 2), (2, 20.0))
+    self.assertEqual(self.p._Display(-1, 2), (2, 20.0, 10))
     self.assertEqual(self._output.Show(), '0\n1\n')
     self._output.Clear()
     # Display the rest of the text.
-    self.assertEqual(self.p._Display(7), (10, 100.0))
+    self.assertEqual(self.p._Display(7), (10, 100.0, 10))
     self.assertEqual(self._output.Show(), '7\n8\n9\n')
 
   def testPageAddsText(self):
@@ -185,9 +185,8 @@ class PagerTest(unittest.TestCase):
     # After paging once the progress will be 20%.
     self.p.Page()
     self._output.Clear()
-    # Confirm that prompt is at 20%
     self.assertEqual(self.p._Prompt(), terminal.AnsiText(
-      'n: next line, Space: next page, b: prev page, q: quit. (20%)',
+      'n: next line, Space: next page, b: prev page, q: quit.',
       ['green']))
     # truncate width to 10 cols, prompt should be likewise truncated.
     self.p._cols = 10
@@ -205,50 +204,39 @@ class PagerTest(unittest.TestCase):
     self.assertEqual(self._output.Show().splitlines()[:-self._prompt_lines],
                      ['0', '1'])
 
-  def testPageOffEnd(self):
-    self.p.SetLines(6)
-    # Quitting mid-pagination returns False.
-    self.assertFalse(self.p.Page())
-    # Paging to the end of the file returns True.
-    self.assertTrue(self.p.Page())
-
-  def testPageAdd(self):
-    self.p.SetLines(6)
-    # Quitting mid-pagination returns False.
-    self.assertFalse(self.p.Page())
-    # Clear output we aren't testing.
-    self._output.Clear()
-    # Paging to the end of the file returns True.
-    self.assertTrue(self.p.Page('10\n11\n'))
-    # We don't split the prompt off here, because we have reached the end.
-    self.assertEqual(self._output.Show().splitlines(),
-                     ['6', '7', '8', '9', '10', '11'])
-    
-    self.p.Reset()
-    self.assertFalse(self.p.Page())
-    self.assertTrue(self.p.Page())
-    # Clear output we aren't testing.
-    self._output.Clear()
-    self.assertTrue(self.p.Page())
-    # At the end, so nothing to show.
-    self.assertEqual(self._output.Show(), '')
-    # New data added, so we can page again.
-    self.assertTrue(self.p.Page('12\n13\n'))
-    self.assertEqual(self._output.Show().splitlines(), ['12', '13'])
-
   def testPageAddPercent(self):
     self.p.SetLines(2)
     self.p.Page()
-    self.assertEqual(self.p._percent, 20)
+    self.assertEqual(terminal.StripAnsiText(
+      self._output.Show().splitlines()[-self._prompt_lines]),
+      terminal.PROMPT_QUESTION + ' (20%)')
     self.p.Page()
-    self.assertEqual(self.p._percent, 40)
+    self.assertEqual(terminal.StripAnsiText(
+      self._output.Show().splitlines()[-self._prompt_lines]),
+      terminal.PROMPT_QUESTION + ' (40%)')
     self.p.Page('10\n11\n')
-    # 505, rather than 60%, as the total size increased from 10 to 12.
-    self.assertEqual(self.p._percent, 50)
+    # 50%, rather than 60%, as the total size increased from 10 to 12.
+    # But we don't show percent, as the source is streamed.
+    self.assertEqual(terminal.StripAnsiText(
+      self._output.Show().splitlines()[-self._prompt_lines]),
+      terminal.PROMPT_QUESTION)
     self.p.Page('12\n13\n14\n15')
-    self.assertEqual(self.p._percent, 50)
+    self.assertEqual(terminal.StripAnsiText(
+      self._output.Show().splitlines()[-self._prompt_lines]),
+      terminal.PROMPT_QUESTION)
     self.p.Page()
-    self.assertEqual(self.p._percent, 10 / 16 * 100)
+    self.assertEqual(terminal.StripAnsiText(
+      self._output.Show().splitlines()[-self._prompt_lines]),
+      terminal.PROMPT_QUESTION + ' (%d%%)' % (10 / 16 * 100))
+
+  def testBlankLines(self):
+    _buffer = 'First line.\n\nThird line.\n'
+    self.p = terminal.Pager(_buffer)
+    self.p.SetLines(4)
+    self.p.Page()
+    self.assertEqual(self._output.Show().splitlines()[:-self._prompt_lines],
+      _buffer.splitlines())
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -110,7 +110,9 @@ class FakeTerminal(object):
 
   # pylint: disable=C6409
   def write(self, text):
-    self.output += text
+    # Ignore initial clear screen output.
+    if text != '\033[2J\033[H':
+      self.output += text
 
   # pylint: disable=C6409
   def CountLines(self):

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -151,22 +151,22 @@ class PagerTest(unittest.TestCase):
 
   def testDisplay(self):
     # Display a couple of rows (20%).
-    self.assertEqual(self.p._Display(0, 2), 20.0)
+    self.assertEqual(self.p._Display(0, 2), (2, 20.0))
     self.assertEqual(self._output.Show(), '0\n1\n')
     self._output.Clear()
-    self.assertEqual(self.p._Display(3, 5), 50.0)
+    self.assertEqual(self.p._Display(3, 2), (5, 50.0))
     self.assertEqual(self._output.Show(), '3\n4\n')
     self._output.Clear()
     # Display past the end of the text.
-    self.assertEqual(self.p._Display(8, 11), 100.0)
+    self.assertEqual(self.p._Display(8, 3), (10, 100.0))
     self.assertEqual(self._output.Show(), '8\n9\n')
     self._output.Clear()
-    # Display before the start.
-    self.assertEqual(self.p._Display(-1, 1), 10.0)
-    self.assertEqual(self._output.Show(), '0\n')
+    # Display before the start. Displays form the start.
+    self.assertEqual(self.p._Display(-1, 2), (2, 20.0))
+    self.assertEqual(self._output.Show(), '0\n1\n')
     self._output.Clear()
     # Display the rest of the text.
-    self.assertEqual(self.p._Display(7), 100.0)
+    self.assertEqual(self.p._Display(7), (10, 100.0))
     self.assertEqual(self._output.Show(), '7\n8\n9\n')
 
   def testPageAddsText(self):
@@ -187,12 +187,12 @@ class PagerTest(unittest.TestCase):
     self._output.Clear()
     # Confirm that prompt is at 20%
     self.assertEqual(self.p._Prompt(), terminal.AnsiText(
-      'Enter: next line, Space: next page, b: prev page, q: quit. (20%)',
+      'n: next line, Space: next page, b: prev page, q: quit. (20%)',
       ['green']))
     # truncate width to 10 cols, prompt should be likewise truncated.
     self.p._cols = 10
     self.assertEqual(self.p._Prompt(),
-                     terminal.AnsiText('Enter: nex', ['green']))
+                     terminal.AnsiText('n: next li', ['green']))
     
   def testPagerClear(self):
     self.p.SetLines(2)

--- a/textfsm/terminal.py
+++ b/textfsm/terminal.py
@@ -94,6 +94,9 @@ ANSI_END = '\002'
 UP_ARROW = '\033[A'
 DOWN_ARROW = '\033[B'
 
+# Clear the screen and move the cursor to the top left.
+CLEAR_SCREEN = '\033[2J\033[H'
+
 # Navigational instructions for the user of the pager.
 PROMPT_QUESTION = 'n: next line, Space: next page, b: prev page, q: quit.'
 
@@ -388,8 +391,7 @@ class Pager(object):
     else:
       end = min(start + length, total_length)
 
-    # Clear the screen.
-    self._WriteOut('\033[2J\033[H')
+    self._WriteOut(CLEAR_SCREEN)
     for i in range(start, end):
       print(text_list[i])
       if self._delay:

--- a/textfsm/terminal.py
+++ b/textfsm/terminal.py
@@ -22,14 +22,7 @@ import re
 import shutil
 import sys
 import time
-
-try:
-  # Import fails on Windows machines.
-  import fcntl  # pylint: disable=g-import-not-at-top
-  import termios  # pylint: disable=g-import-not-at-top
-  import tty  # pylint: disable=g-import-not-at-top
-except (ImportError, ModuleNotFoundError):
-  pass
+import typing
 
 # ANSI, ISO/IEC 6429 escape sequences, SGR (Select Graphic Rendition) subset.
 SGR = {
@@ -92,13 +85,62 @@ BG_COLOR_WORDS = {
     'grey': ['bg_white'],
 }
 
-
 # Characters inserted at the start and end of ANSI strings
 # to provide hinting for readline and other clients.
 ANSI_START = '\001'
 ANSI_END = '\002'
 
+# Arrow key sequences.
+UP_ARROW = '\033[A'
+DOWN_ARROW = '\033[B'
 
+def _GetChar() -> str:
+  """Read a single character from the tty.
+
+  Returns:
+    A string, the character read.
+  """
+  # Default to 'q' to quit out of paging content.
+  return 'q'
+
+try:
+  # Import fails on Windows machines.
+  # pylint: disable=g-import-not-at-top
+  import termios
+  import tty
+
+  def _PosixGetChar() -> str:
+    try:
+      _tty = open('/dev/tty')
+    except IOError:
+      # No TTY, revert to stdin
+      _tty = sys.stdin
+    fd = _tty.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+      tty.setraw(fd)
+      ch = _tty.read(1)
+      # Also support arrow key shortcuts (escape + 2 chars)
+      if ord(ch) == 27:
+        ch += _tty.read(2)
+    finally:
+      termios.tcsetattr(fd, termios.TCSADRAIN, old)
+      if '_tty' is not sys.stdin:
+        _tty.close()
+    return ch
+  _GetChar = _PosixGetChar
+except (ImportError, ModuleNotFoundError):
+  # If we are on MS Windows then try using msvcrt library instead.
+  import msvcrt
+  def _MSGetChar() -> str:
+    ch = msvcrt.getch()                                                         # type: ignore
+      # Also support arrow key shortcuts (escape + 2 chars)
+    if ord(ch) == 27:
+      ch += msvcrt.getch()                                                      # type: ignore
+    return ch
+  _GetChar = _MSGetChar
+
+# Regular expression to match ANSI/SGR escape sequences.
 sgr_re = re.compile(r'(%s?\033\[\d+(?:;\d+)*m%s?)' % (ANSI_START, ANSI_END))
 
 
@@ -251,7 +293,7 @@ class Pager(object):
   displayed, or the user has quit the pager.
 
   Currently supported keybindings are:
-    <enter> - one line down
+    n - one line down
     <down arrow> - one line down
     b - one page up
     <up arrow> - one line up
@@ -260,7 +302,7 @@ class Pager(object):
     <space> - one page down
   """
 
-  def __init__(self, text=None, delay=None):
+  def __init__(self, text: str = '', delay: bool = False) -> None:
     """Constructor.
 
     Args:
@@ -268,49 +310,83 @@ class Pager(object):
       delay: A boolean, if True will cause a slight delay between line printing
         for more obvious scrolling.
     """
-    self._text = text or ''
-    self._delay = delay
-    try:
-      self._tty = open('/dev/tty')
-    except IOError:
-      # No TTY, revert to stdin
-      self._tty = sys.stdin
-    self.SetLines(None)
+    self._text = text
     self.Reset()
+    self.SetLines()
+    # Add 0.005 sec delay between lines.
+    if delay:
+      self._delay = 0.005
+    else:
+      self._delay = 0
 
-  def __del__(self):
-    """Deconstructor, closes tty."""
-    if getattr(self, '_tty', sys.stdin) is not sys.stdin:
-      self._tty.close()
-
-  def Reset(self):
+  def Reset(self) -> None:
     """Reset the pager to the top of the text."""
-    self._displayed = 0
-    self._currentpagelines = 0
-    self._lastscroll = 1
-    self._lines_to_show = self._cli_lines
+    self.first_line = 0
+    self._percent = 0
 
-  def SetLines(self, lines):
-    """Set number of screen lines.
+  def SetLines(self, lines: int = 0) -> typing.Tuple[int, int]:
+    """Set number of lines to display at a time.
 
     Args:
-      lines: An int, number of lines. If None, use terminal dimensions.
+      lines: An int, number of lines. If 0 use terminal dimensions.
+        Maximum number should be one less than full terminal height,
+        to allow for a user prompt. 
 
     Raises:
       ValueError, TypeError: Not a valid integer representation.
     """
 
-    (self._cli_cols, self._cli_lines) = shutil.get_terminal_size()
+    # Get the terminal size.
+    (_cols, _lines) = shutil.get_terminal_size()
+    # If we want paging by other than a whole window height.
+    # For a whole window height, we drop one line to leave room for prompting.
+    self._lines = int(lines) or _lines - 1
+    # Must be at least two rows, one row of output and one for the prompt.
+    self._lines = max(2, self._lines)
+    # Only number of rows is user configurable, we keep the terminal width.
+    self._cols = _cols
+    return (self._cols, self._lines)
 
-    if lines:
-      self._cli_lines = int(lines)
-
-  def Clear(self):
+  def Clear(self) -> None:
     """Clear the text and reset the pager."""
     self._text = ''
     self.Reset()
 
-  def Page(self, text=None, show_percent=None):
+  def _Display(self, start: int, length: int = 0) -> typing.Tuple[int, float]:
+    """Display a range of lines from the text.
+
+    Args:
+      start: An int, the first line to display.
+      end: An int, the last line to display.
+    Returns:
+      An int, the percentage of the text displayed so far.
+    """
+
+    # Break text on newlines. But also break on line wrap.
+    _text_list = LineWrap(self._text).splitlines()
+
+    # Bound start and end to be within the text.
+    start = max(0, start)
+    # If open-ended, trim to be whole of text.
+    if not length:
+      end = len(_text_list)
+    else:
+      end = min(start + length, len(_text_list))
+
+    for i in range(start, end):
+      self._WriteOut(_text_list[i] + '\n')
+      if self._delay:
+        time.sleep(self._delay)
+
+    # Returns exactly '100' percent once all lines are displayed.
+    return (end, end / len(_text_list) * 100)
+
+  def _WriteOut(self, text: str) -> None:
+    """Write text to stdout."""
+    sys.stdout.write(text)
+    sys.stdout.flush()
+
+  def Page(self, more_text: str = '') -> bool:
     """Page text.
 
     Continues to page through any text supplied in the constructor. Also, any
@@ -319,117 +395,87 @@ class Pager(object):
     the user, or the user quits the pager.
 
     Args:
-      text: A string, extra text to be paged.
-      show_percent: A boolean, if True, indicate how much is displayed so far.
-        If None, this behaviour is 'text is None'.
+      more_text: A string, extra text to be paged.
 
     Returns:
-      A boolean. If True, more data can be displayed to the user. False
-        implies that the user has quit the pager.
+      A boolean. False indicates the user has quit the pager.
     """
-    if text is not None:
-      self._text += text
 
-    if show_percent is None:
-      show_percent = text is None
-    self._show_percent = show_percent
+    # With each page, more text can be added.
+    if more_text:
+      self._text += more_text
 
-    text = LineWrap(self._text).splitlines()
-    while True:
-      # Get a list of new lines to display.
-      self._newlines = text[
-          self._displayed : self._displayed + self._lines_to_show
-      ]
-      for line in self._newlines:
-        sys.stdout.write(line + '\n')
-        if self._delay and self._lastscroll > 0:
-          time.sleep(0.005)
-      self._displayed += len(self._newlines)
-      self._currentpagelines += len(self._newlines)
-      if self._currentpagelines >= self._lines_to_show:
-        self._currentpagelines = 0
-        wish = self._AskUser()
-        if wish == 'q':  # Quit pager.
-          return False
-        elif wish == 'g':  # Display till the end.
-          self._Scroll(len(text) - self._displayed + 1)
-        elif wish == '\r':  #  Enter, down a line.
-          self._Scroll(1)
-        elif wish == '\033[B':  # Down arrow, down a line.
-          self._Scroll(1)
-        elif wish == '\033[A':  # Up arrow, up a line.
-          self._Scroll(-1)
-        elif wish == 'b':  # Up a page.
-          self._Scroll(0 - self._cli_lines)
-        else:  # Next page.
-          self._Scroll()
-      if self._displayed >= len(text):
+    _end = self.first_line
+    # While there is more text to be displayed.
+    while self._percent < 100 or more_text:
+      # Display a page of output.
+      (_end, self._percent) = self._Display(self.first_line, self._lines)
+
+      if self._percent >= 100:
+        # There is no more pages to display, skip prompting.
         break
+      else:
+        # If there is more content then prompt for what to display next.
+        wish = self._PromptUser()
 
-    return True
+        if wish == 'g':           # Display the remaining content.
+          (_end, self._percent) = self._Display(self.first_line + self._lines)
+          # There is no more pages to display, skip prompting.
+          break
 
-  def _Scroll(self, lines=None):
-    """Set attributes to scroll the buffer correctly.
+        if wish == 'q':           # Quit.
+          # Progress forward by a page.
+          self.first_line += self._lines
+          # Indicate that we have not shown the full document.
+          return False
 
-    Args:
-      lines: An int, number of lines to scroll. If None, scrolls by the terminal
-        length.
-    """
-    if lines is None:
-      lines = self._cli_lines
+        if wish == 'n':
+          # Enter, down a line.
+          self.first_line += 1
+        elif wish == DOWN_ARROW:
+          # Down a line.
+          self.first_line += 1
+        elif wish == UP_ARROW:
+          # Up a line.
+          self.first_line -= 1
+        elif wish == 'b':
+          # Up a page.
+          self.first_line -= self._lines
+        else:
+          # Down a page.
+          self.first_line += self._lines
+        
+        # Bound the first line to be at, or after, the text.
+        self.first_line = max(0, self.first_line)
 
-    if lines < 0:
-      self._displayed -= self._cli_lines
-      self._displayed += lines
-      if self._displayed < 0:
-        self._displayed = 0
-      self._lines_to_show = self._cli_lines
-    else:
-      self._lines_to_show = lines
+    # We have displayed everything, set first_line to the end.
+    self.first_line = _end
+    
+    return True     # We have shown the full content.
 
-    self._lastscroll = lines
+  def _Prompt(self) -> str:
+    _percent = ' (%d%%)' % self._percent
+    question = ('n: next line, Space: next page, b: prev page, q: quit.'
+                + _percent)
+    # Truncate prompt to width of display.
+    question = question[:self._cols]
+    # Colorize the prompt.
+    return AnsiText(question, ['green'])
 
-  def _AskUser(self):
+  def _ClearPrompt(self) -> str:
+    """Clear the prompt by over printing blank characters."""
+    return '\r%s\r' % (' ' * self._cols)
+
+  def _PromptUser(self) -> str:
     """Prompt the user for the next action.
 
     Returns:
       A string, the character entered by the user.
     """
-    if self._show_percent:
-      progress = int(self._displayed * 100 / (len(self._text.splitlines())))
-      progress_text = ' (%d%%)' % progress
-    else:
-      progress_text = ''
-    question = AnsiText(
-        'Enter: next line, Space: next page, b: prev page, q: quit.%s'
-        % progress_text,
-        ['green'],
-    )
-    sys.stdout.write(question)
-    sys.stdout.flush()
-    ch = self._GetCh()
-    sys.stdout.write('\r%s\r' % (' ' * len(question)))
-    sys.stdout.flush()
+    self._WriteOut(self._Prompt())
+    ch = _GetChar()
+    self._WriteOut(self._ClearPrompt())
     return ch
-
-  def _GetCh(self):
-    """Read a single character from the user.
-
-    Returns:
-      A string, the character read.
-    """
-    fd = self._tty.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-      tty.setraw(fd)
-      ch = self._tty.read(1)
-      # Also support arrow key shortcuts (escape + 2 chars)
-      if ord(ch) == 27:
-        ch += self._tty.read(2)
-    finally:
-      termios.tcsetattr(fd, termios.TCSADRAIN, old)
-    return ch
-
 
 def main(argv=None):
   """Routine to page text or determine window size via command line."""

--- a/textfsm/terminal.py
+++ b/textfsm/terminal.py
@@ -357,9 +357,9 @@ class Pager(object):
 
     Args:
       start: An int, the first line to display.
-      end: An int, the last line to display.
+      length: An int, the number of lines to display.
     Returns:
-      An int, the percentage of the text displayed so far.
+      Tuple, the next line after, and a percentage for where that line is.
     """
 
     # Break text on newlines. But also break on line wrap.
@@ -378,7 +378,6 @@ class Pager(object):
       if self._delay:
         time.sleep(self._delay)
 
-    # Returns exactly '100' percent once all lines are displayed.
     return (end, end / len(_text_list) * 100)
 
   def _WriteOut(self, text: str) -> None:
@@ -395,10 +394,10 @@ class Pager(object):
     the user, or the user quits the pager.
 
     Args:
-      more_text: A string, extra text to be paged.
+      more_text: A string, extra text to be appended.
 
     Returns:
-      A boolean. False indicates the user has quit the pager.
+      A boolean: True: we have reached the end. False: the user has quit early. 
     """
 
     # With each page, more text can be added.
@@ -495,7 +494,7 @@ def main(argv=None):
       print(help_msg)
       return 0
 
-  isdelay = False
+  _is_delay = False
   for opt, _ in opts:
     # Prints the size of the terminal and returns.
     # Mutually exclusive to the paging of text and overrides that behaviour.
@@ -504,7 +503,7 @@ def main(argv=None):
         'Width: %d, Length: %d' % shutil.get_terminal_size())
       return 0
     elif opt in ('-d', '--delay'):
-      isdelay = True
+      _is_delay = True
     else:
       raise UsageError('Invalid arguments.')
 
@@ -515,7 +514,7 @@ def main(argv=None):
       fd = f.read()
   else:
     fd = sys.stdin.read()
-  Pager(fd, delay=isdelay).Page()
+  Pager(fd, delay=_is_delay).Page()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While preparing the 2.0.0 release I noticed some inconsistent Pager behaviour.
I subsequently ran into trouble trying to localise the issue by adding tests...
So I spent the weekend refactoring the Pager class to make unit testing easier. I added many more tests, then found and resolved several issues.

Issue(s) resolved:
  SetLines was being ignored
  Percent was conditionally displayed
  Only every 2nd 'enter' key was being registered by tty.read
  Prompt string did not truncate on narrow terminals
  Added support for MS Windows

Apologies for the lengthy CL - I combined it all together so we can proceed with system/regression test as part of this CL review.